### PR TITLE
[BUGFIX] Load remotely saved freeboard

### DIFF
--- a/js/freeboard/freeboard.js
+++ b/js/freeboard/freeboard.js
@@ -2300,6 +2300,9 @@ var freeboard = (function()
 						{
 							finishedCallback();
 						}
+
+                        theFreeboardModel.allow_edit(allowEdit);
+                        theFreeboardModel.setEditing(allowEdit);
 					}
 				});
 			}


### PR DESCRIPTION
When you load a freeboard (remotely) the dashbaord is placed
before the header section.

![freeboard](https://cloud.githubusercontent.com/assets/551974/3071163/4afd607c-e2b3-11e3-9541-e0c816d28413.png)

In order to load an external resource use GET params: ?load=remote-endpoint.json