### PR TITLE
feat: auto load a URL given as fragment

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,6 +29,16 @@
                     $(function()
                     { //DOM Ready
                         freeboard.initialize(true);
+
+                        var hashpattern = window.location.hash.match(/(&|#)source=([^&]+)/);
+                        if (hashpattern !== null) {
+                            $.get(hashpattern[2], function(data) {
+                                freeboard.loadDashboard(data, function() {
+                                    freeboard.setEditing(false);
+                                });
+                            });
+                        }
+
                     });
                 });
     </script>


### PR DESCRIPTION
For example, loading

    http://host.com/freeboard/index.html#source=/api/dashboard.json

will autoload that configuration when the page is loaded. This makes it really
convenient to avoid having to make `index.html` autogenerated. It also makes it
easier to have multiple dashboards using the same `index.html`.