### PR TITLE
Made picture widget preload before refreshing

### DIFF
--- a/plugins/freeboard/freeboard.widgets.js
+++ b/plugins/freeboard/freeboard.widgets.js
@@ -663,15 +663,19 @@
             }
         }
 
-        function updateImage()
+				function updateImage()
         {
             if(widgetElement && imageURL)
             {
-                var cacheBreakerURL = imageURL + (imageURL.indexOf("?") == -1 ? "?" : "&") + Date.now();
+                var cacheBreakerURL = imageURL + (imageURL.indexOf("?") == -1 ? "?" : "&") + Date.now(),
+										img = new Image();
 
-                $(widgetElement).css({
-                    "background-image" :  "url(" + cacheBreakerURL + ")"
-                });
+								img.onload = function() {
+									$(widgetElement).css({
+											"background-image" :  "url(" + cacheBreakerURL + ")"
+									});
+								}
+								img.src = cacheBreakerURL;
             }
         }
 


### PR DESCRIPTION
I noticed that when I hooked a picture element to my security camera and had it refreshing each second there was a noticeable load/flicker. With the pre loading this is much smoother.