### PR TITLE
Fixed saveDialog for firefox.

### DIFF
--- a/lib/js/freeboard/FreeboardModel.js
+++ b/lib/js/freeboard/FreeboardModel.js
@@ -274,7 +274,7 @@ function FreeboardModel(datasourcePlugins, widgetPlugins, freeboardUI)
 		}
 	}
 
-	this.saveDashboardClicked = function(){
+	this.saveDashboardClicked = function(_thisref, event){
 		var target = $(event.currentTarget);
 		var siblingsShown = target.data('siblings-shown') || false;
 		if(!siblingsShown){


### PR DESCRIPTION
I've tested this in firefox 40.0 under Linux, and it fixes the dialog problem I reported.