### PR TITLE
.form-row clear floating not correct

### DIFF
--- a/lib/css/freeboard/styles.css
+++ b/lib/css/freeboard/styles.css
@@ -1655,7 +1655,9 @@ ul, ol {
 	float: left;
 }
 
-.form-row {
+.form-row:after {
+	content: '';
+	display: block;
 	clear: both;
 }
 


### PR DESCRIPTION
.form-row's element cant expand the height when wrapping the element with floating options.
`clear: both` need to set after the floating element. They are siblings ~