### PR TITLE
:bug: Update uglify compress option. Fixes #160

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -76,7 +76,7 @@ module.exports = function(grunt) {
                 options: {
                     mangle : false,
                     beautify : false,
-                    compress: true
+                    compress: {}
                 },
                 files: {
                     'js/freeboard.thirdparty.min.js' : [ 'js/freeboard.thirdparty.js' ]


### PR DESCRIPTION
This commit changes compress option in Grunt
uglify configuration to use latest syntax version.
This will remove 'TypeError: Cannot assign to read only property
'warnings' of true'.
See: @gruntjs/grunt-contrib-uglify/#298

Thanks!