### PR TITLE
fix bug in dweetio datasource plugin

### DIFF
--- a/plugins/freeboard/freeboard.datasources.js
+++ b/plugins/freeboard/freeboard.datasources.js
@@ -305,7 +305,7 @@
 		}
 
 		this.onSettingsChanged = function (newSettings) {
-			dweetio.stop_listening();
+			dweetio.stop_listening_for(currentSettings.thing_id);
 
 			currentSettings = newSettings;
 


### PR DESCRIPTION
when dweetio datasource's settings changed, it should only stop the listener for its own thing, instead of all listeners. the old codes will cause issue when there are 1+ dweetio datasources