### PR TITLE
Do not fail when external_scripts is an empty array.

### DIFF
--- a/js/freeboard.js
+++ b/js/freeboard.js
@@ -56,7 +56,7 @@ DatasourceModel = function(theFreeboardModel, datasourcePlugins) {
 			}
 
 			// Do we need to load any external scripts?
-			if(datasourceType.external_scripts)
+			if(datasourceType.external_scripts && datasourceType.external_scripts.length > 0)
 			{
 				head.js(datasourceType.external_scripts.slice(0), finishLoad); // Need to clone the array because head.js adds some weird functions to it
 			}


### PR DESCRIPTION
Currently when you define external_scripts as an empty array, your datasource is never instantiated.
