### PR TITLE
convert 'col_width' to num before using it as num

### DIFF
--- a/lib/js/freeboard/FreeboardUI.js
+++ b/lib/js/freeboard/FreeboardUI.js
@@ -22,7 +22,8 @@ function FreeboardUI()
 				var paneModel = ko.dataFor(paneElement);
 
 				var newPosition = getPositionForScreenSize(paneModel);
-				$(paneElement).attr("data-sizex", Math.min(paneModel.col_width(),
+				var col_width = Number(paneModel.col_width());
+				$(paneElement).attr("data-sizex", Math.min(col_width,
 					maxDisplayableColumns, grid.cols))
 					.attr("data-row", newPosition.row)
 					.attr("data-col", newPosition.col);
@@ -61,7 +62,8 @@ function FreeboardUI()
 					rightPreviewCol = true;
 					newPosition = {row: prevRow, col: prevCol};
 				}
-				$(paneElement).attr("data-sizex", Math.min(paneModel.col_width(), grid.cols))
+				var col_width = Number(paneModel.col_width());
+				$(paneElement).attr("data-sizex", Math.min(col_width, grid.cols))
 					.attr("data-row", newPosition.row)
 					.attr("data-col", newPosition.col);
 			});
@@ -93,7 +95,8 @@ function FreeboardUI()
 					var newCol = prevCol <= grid.cols ? prevCol : grid.cols;
 					newPosition = {row: prevRow, col: newCol};
 				}
-				$(paneElement).attr("data-sizex", Math.min(paneModel.col_width(), grid.cols))
+				var col_width = Number(paneModel.col_width());
+				$(paneElement).attr("data-sizex", Math.min(col_width, grid.cols))
 					.attr("data-row", newPosition.row)
 					.attr("data-col", newPosition.col);
 			});
@@ -244,9 +247,10 @@ function FreeboardUI()
 		var elementHeight = Number($(element).attr("data-sizey"));
 		var elementWidth = Number($(element).attr("data-sizex"));
 
-		if(calculatedHeight != elementHeight || viewModel.col_width() !=  elementWidth)
+		var col_width = Number(viewModel.col_width());
+		if(calculatedHeight != elementHeight ||  col_width !=  elementWidth)
 		{
-			grid.resize_widget($(element), viewModel.col_width(), calculatedHeight, function(){
+			grid.resize_widget($(element), col_width, calculatedHeight, function(){
 				grid.set_dom_grid_height();
 			});
 		}
@@ -256,8 +260,8 @@ function FreeboardUI()
 	{
 		var displayCols = grid.cols;
 
-		if(!_.isUndefined(row)) paneModel.row[displayCols] = row;
-		if(!_.isUndefined(col)) paneModel.col[displayCols] = col;
+		if(!_.isUndefined(row)) paneModel.row[displayCols] = Math.max(1, row);
+		if(!_.isUndefined(col)) paneModel.col[displayCols] = Math.max(1, col);
 	}
 
 	function showLoadingIndicator(show)


### PR DESCRIPTION
The data-sizex will be set directly by value of paneModel.col_width(),
and by default paneModel.col_width() is a number string, not number.
This will cause issues when gridster plugin trys to caclulate layout,
because for example 'string number'+'real number' will return a string
with two number string concated, not a number("1" + 3 = "13"), I think
this may cause some weird layout issue.