### PR TITLE
convert integer type setting to integer

### DIFF
--- a/lib/js/freeboard/FreeboardUI.js
+++ b/lib/js/freeboard/FreeboardUI.js
@@ -22,7 +22,8 @@ function FreeboardUI()
 				var paneModel = ko.dataFor(paneElement);
 
 				var newPosition = getPositionForScreenSize(paneModel);
-				$(paneElement).attr("data-sizex", Math.min(paneModel.col_width(),
+				var col_width = Number(paneModel.col_width());
+				$(paneElement).attr("data-sizex", Math.min(col_width,
 					maxDisplayableColumns, grid.cols))
 					.attr("data-row", newPosition.row)
 					.attr("data-col", newPosition.col);
@@ -61,7 +62,8 @@ function FreeboardUI()
 					rightPreviewCol = true;
 					newPosition = {row: prevRow, col: prevCol};
 				}
-				$(paneElement).attr("data-sizex", Math.min(paneModel.col_width(), grid.cols))
+				var col_width = Number(paneModel.col_width());
+				$(paneElement).attr("data-sizex", Math.min(col_width, grid.cols))
 					.attr("data-row", newPosition.row)
 					.attr("data-col", newPosition.col);
 			});
@@ -93,7 +95,8 @@ function FreeboardUI()
 					var newCol = prevCol <= grid.cols ? prevCol : grid.cols;
 					newPosition = {row: prevRow, col: newCol};
 				}
-				$(paneElement).attr("data-sizex", Math.min(paneModel.col_width(), grid.cols))
+				var col_width = Number(paneModel.col_width());
+				$(paneElement).attr("data-sizex", Math.min(col_width, grid.cols))
 					.attr("data-row", newPosition.row)
 					.attr("data-col", newPosition.col);
 			});
@@ -244,9 +247,10 @@ function FreeboardUI()
 		var elementHeight = Number($(element).attr("data-sizey"));
 		var elementWidth = Number($(element).attr("data-sizex"));
 
-		if(calculatedHeight != elementHeight || viewModel.col_width() !=  elementWidth)
+		var col_width = Number(viewModel.col_width());
+		if(calculatedHeight != elementHeight ||  col_width !=  elementWidth)
 		{
-			grid.resize_widget($(element), viewModel.col_width(), calculatedHeight, function(){
+			grid.resize_widget($(element), col_width, calculatedHeight, function(){
 				grid.set_dom_grid_height();
 			});
 		}
@@ -256,8 +260,8 @@ function FreeboardUI()
 	{
 		var displayCols = grid.cols;
 
-		if(!_.isUndefined(row)) paneModel.row[displayCols] = row;
-		if(!_.isUndefined(col)) paneModel.col[displayCols] = col;
+		if(!_.isUndefined(row)) paneModel.row[displayCols] = Math.max(1, row);
+		if(!_.isUndefined(col)) paneModel.col[displayCols] = Math.max(1, col);
 	}
 
 	function showLoadingIndicator(show)

--- a/lib/js/freeboard/FreeboardUI.js
+++ b/lib/js/freeboard/FreeboardUI.js
@@ -22,8 +22,7 @@ function FreeboardUI()
 				var paneModel = ko.dataFor(paneElement);
 
 				var newPosition = getPositionForScreenSize(paneModel);
-				var col_width = Number(paneModel.col_width());
-				$(paneElement).attr("data-sizex", Math.min(col_width,
+				$(paneElement).attr("data-sizex", Math.min(paneModel.col_width(),
 					maxDisplayableColumns, grid.cols))
 					.attr("data-row", newPosition.row)
 					.attr("data-col", newPosition.col);
@@ -62,8 +61,7 @@ function FreeboardUI()
 					rightPreviewCol = true;
 					newPosition = {row: prevRow, col: prevCol};
 				}
-				var col_width = Number(paneModel.col_width());
-				$(paneElement).attr("data-sizex", Math.min(col_width, grid.cols))
+				$(paneElement).attr("data-sizex", Math.min(paneModel.col_width(), grid.cols))
 					.attr("data-row", newPosition.row)
 					.attr("data-col", newPosition.col);
 			});
@@ -95,8 +93,7 @@ function FreeboardUI()
 					var newCol = prevCol <= grid.cols ? prevCol : grid.cols;
 					newPosition = {row: prevRow, col: newCol};
 				}
-				var col_width = Number(paneModel.col_width());
-				$(paneElement).attr("data-sizex", Math.min(col_width, grid.cols))
+				$(paneElement).attr("data-sizex", Math.min(paneModel.col_width(), grid.cols))
 					.attr("data-row", newPosition.row)
 					.attr("data-col", newPosition.col);
 			});
@@ -247,10 +244,9 @@ function FreeboardUI()
 		var elementHeight = Number($(element).attr("data-sizey"));
 		var elementWidth = Number($(element).attr("data-sizex"));
 
-		var col_width = Number(viewModel.col_width());
-		if(calculatedHeight != elementHeight ||  col_width !=  elementWidth)
+		if(calculatedHeight != elementHeight || viewModel.col_width() !=  elementWidth)
 		{
-			grid.resize_widget($(element), col_width, calculatedHeight, function(){
+			grid.resize_widget($(element), viewModel.col_width(), calculatedHeight, function(){
 				grid.set_dom_grid_height();
 			});
 		}
@@ -260,8 +256,8 @@ function FreeboardUI()
 	{
 		var displayCols = grid.cols;
 
-		if(!_.isUndefined(row)) paneModel.row[displayCols] = Math.max(1, row);
-		if(!_.isUndefined(col)) paneModel.col[displayCols] = Math.max(1, col);
+		if(!_.isUndefined(row)) paneModel.row[displayCols] = row;
+		if(!_.isUndefined(col)) paneModel.col[displayCols] = col;
 	}
 
 	function showLoadingIndicator(show)

--- a/lib/js/freeboard/PluginEditor.js
+++ b/lib/js/freeboard/PluginEditor.js
@@ -338,7 +338,11 @@ PluginEditor = function(jsEditor, valueEditor)
 								{
 									newSettings.settings[settingDef.name] = Number($(this).val());
 								}
-								else
+								else if (settingDef.type == "integer")
+                {
+									newSettings.settings[settingDef.name] = parseInt($(this).val());
+                }
+                else
 								{
 									newSettings.settings[settingDef.name] = $(this).val();
 								}

--- a/lib/js/freeboard/PluginEditor.js
+++ b/lib/js/freeboard/PluginEditor.js
@@ -339,10 +339,10 @@ PluginEditor = function(jsEditor, valueEditor)
 									newSettings.settings[settingDef.name] = Number($(this).val());
 								}
 								else if (settingDef.type == "integer")
-                {
+								{
 									newSettings.settings[settingDef.name] = parseInt($(this).val());
-                }
-                else
+								}
+								else
 								{
 									newSettings.settings[settingDef.name] = $(this).val();
 								}


### PR DESCRIPTION
AFAIU, there is only one integer type setting, that is Pane's 'Columns'.  The columns value wil be used to calculate layout later by gridster plugin. If we don't convert the setting to integer, then it may cause undesired result later, considering plus a string number to a real number like this: '1' + 3 = '13', and then cause some layout issue.