### PR TITLE
Adding docker/docker-compose support.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM node:6
+
+RUN mkdir -p /usr/share/nginx/html
+
+COPY . /usr/share/nginx/html/
+
+RUN chown -R node:node /usr/share/nginx/html
+
+USER node
+
+WORKDIR /usr/share/nginx/html
+
+RUN npm install; \
+    npm install grunt-cli underscore
+
+RUN ./node_modules/.bin/grunt
+
+VOLUME ["/usr/share/nginx/html"]
+
+CMD ["bash"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+version: "2"
+
+services:
+    nginx:
+        image: nginx:1.13
+        ports:
+            - "8003:80"
+        volumes_from:
+            - freeboard:ro
+    freeboard:
+        image: freeboard
+        build: .


### PR DESCRIPTION
Hi, here's something that might make it easier for others who'd like to try freeboard out for themselves.

Running "docker-compose up" will build freeboard and throw Nginx in front of it on local port 8003.