### PR TITLE
Fix #207 by updating grunt versions and including dependencies.

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,11 +3,15 @@
   "title": "freeboard",
   "version": "1.1.3",
   "devDependencies": {
-    "grunt": "0.4.1",
+    "grunt": "1.3.0",
     "grunt-contrib-concat": "0.1.3",
-    "grunt-contrib-cssmin": "0.6.1",
-    "grunt-contrib-watch": "0.5.3",
-    "grunt-contrib-uglify": "0.6.0",
-    "grunt-string-replace": "^0.2.7"
+    "grunt-contrib-cssmin": "3.0.0",
+    "grunt-contrib-uglify": "5.0.0",
+    "grunt-contrib-watch": "1.1.0",
+    "grunt-string-replace": "0.2.7"
+  },
+  "dependencies": {
+    "grunt-cli": "1.3.2",
+    "underscore": "1.11.0"
   }
 }


### PR DESCRIPTION
This commit updates the dependencies in `package.json` and adds the dependencies on `grunt-cli` and `underscore`.