### PR TITLE
Added Light theme and OS dark mode preference support

### DIFF
--- a/index.html
+++ b/index.html
@@ -31,6 +31,7 @@
     </script>
 </head>
 <body>
+
 <div id="board-content">
     <img id="dash-logo" data-bind="attr:{src: header_image}, visible:header_image()">
     <div class="gridster responsive-column-width">
@@ -43,18 +44,23 @@
         <div id="admin-menu">
             <div id="board-tools">
                 <h1 id="board-logo" class="title bordered">freeboard</h1>
+            
                 <div id="board-actions">
+
                     <ul class="board-toolbar vertical">
-                        <li data-bind="click: loadDashboardFromLocalFile"><i id="full-screen-icon" class="icon-folder-open icon-white"></i><label id="full-screen">Load Freeboard</label></li>
-                        <li><i class="icon-download-alt icon-white"></i>
+                        <li data-bind="click: loadDashboardFromLocalFile"><i id="full-screen-icon" class="icon-folder-open icon-prefer"></i><label id="full-screen">Load Freeboard</label></li>
+                        <li><i class="icon-download-alt icon-prefer"></i>
                             <label data-bind="click: saveDashboardClicked">Save Freeboard</label>
                             <label style="display: none;" data-bind="click: saveDashboard" data-pretty="true">[Pretty]</label>
                             <label style="display: none;" data-bind="click: saveDashboard" data-pretty="false">[Minified]</label>
                         </li>
-                        <li id="add-pane" data-bind="click: createPane"><i class="icon-plus icon-white"></i><label>Add Pane</label></li>
+                        <li id="add-pane" data-bind="click: createPane"><i class="icon-plus icon-prefer"></i><label>Add Pane</label></li>
                     </ul>
                 </div>
             </div>
+
+        
+
             <div id="datasources">
                 <h2 class="title">DATASOURCES</h2>
 
@@ -75,9 +81,9 @@
                             <td data-bind="text: last_updated"></td>
                             <td>
                                 <ul class="board-toolbar">
-                                    <li data-bind="click: updateNow"><i class="icon-refresh icon-white"></i></li>
+                                    <li data-bind="click: updateNow"><i class="icon-refresh icon-prefer"></i></li>
                                     <li data-bind="pluginEditor: {operation: 'delete', type: 'datasource'}">
-                                        <i class="icon-trash icon-white"></i></li>
+                                        <i class="icon-trash icon-prefer"></i></li>
                                 </ul>
                             </td>
                         </tr>
@@ -90,16 +96,16 @@
     </div>
 	<div id="column-tools" class="responsive-column-width">
 		<ul class="board-toolbar left-columns">
-			<li class="column-tool add" data-bind="click: addGridColumnLeft"><span class="column-icon right"></span><i class="icon-arrow-left icon-white"></i></li>
-			<li class="column-tool sub" data-bind="click: subGridColumnLeft"><span class="column-icon left"></span><i class="icon-arrow-right icon-white"></i></li>
+			<li class="column-tool add" data-bind="click: addGridColumnLeft"><span class="column-icon right"></span><i class="icon-arrow-left icon-prefer"></i></li>
+			<li class="column-tool sub" data-bind="click: subGridColumnLeft"><span class="column-icon left"></span><i class="icon-arrow-right icon-prefer"></i></li>
 		</ul>
 		<ul class="board-toolbar right-columns">
-			<li class="column-tool sub" data-bind="click: subGridColumnRight"><span class="column-icon right"></span><i class="icon-arrow-left icon-white"></i></li>
-			<li class="column-tool add" data-bind="click: addGridColumnRight"><span class="column-icon left"></span><i class="icon-arrow-right icon-white"></i></li>
+			<li class="column-tool sub" data-bind="click: subGridColumnRight"><span class="column-icon right"></span><i class="icon-arrow-left icon-prefer"></i></li>
+			<li class="column-tool add" data-bind="click: addGridColumnRight"><span class="column-icon left"></span><i class="icon-arrow-right icon-prefer"></i></li>
 		</ul>
 	</div>
     <div id="toggle-header" data-bind="click: toggleEditing">
-        <i id="toggle-header-icon" class="icon-wrench icon-white"></i></div>
+        <i id="toggle-header-icon" class="icon-wrench icon-prefer"></i></div>        
 </header>
 
 <div style="display:hidden">
@@ -113,13 +119,13 @@
             <h1 data-bind="text: title"></h1>
             <ul class="board-toolbar pane-tools">
                 <li data-bind="pluginEditor: {operation: 'add', type: 'widget'}">
-                    <i class="icon-plus icon-white"></i>
+                    <i class="icon-plus icon-prefer"></i>
                 </li>
                 <li data-bind="pluginEditor: {operation: 'edit', type: 'pane'}">
-                    <i class="icon-wrench icon-white"></i>
+                    <i class="icon-wrench icon-prefer"></i>
                 </li>
                 <li data-bind="pluginEditor: {operation: 'delete', type: 'pane'}">
-                    <i class="icon-trash icon-white"></i>
+                    <i class="icon-trash icon-prefer"></i>
                 </li>
             </ul>
         </header>
@@ -129,19 +135,18 @@
                 <div class="sub-section-tools">
                     <ul class="board-toolbar">
                         <!-- ko if:$parent.widgetCanMoveUp($data) -->
-                        <li data-bind="click:$parent.moveWidgetUp"><i class="icon-chevron-up icon-white"></i></li>
+                        <li data-bind="click:$parent.moveWidgetUp"><i class="icon-chevron-up icon-prefer"></i></li>
                         <!-- /ko -->
                         <!-- ko if:$parent.widgetCanMoveDown($data) -->
-                        <li data-bind="click:$parent.moveWidgetDown"><i class="icon-chevron-down icon-white"></i></li>
+                        <li data-bind="click:$parent.moveWidgetDown"><i class="icon-chevron-down icon-prefer"></i></li>
                         <!-- /ko -->
-                        <li data-bind="pluginEditor: {operation: 'edit', type: 'widget'}"><i class="icon-wrench icon-white"></i></li>
-                        <li data-bind="pluginEditor: {operation: 'delete', type: 'widget'}"><i class="icon-trash icon-white"></i></li>
+                        <li data-bind="pluginEditor: {operation: 'edit', type: 'widget'}"><i class="icon-wrench icon-prefer"></i></li>
+                        <li data-bind="pluginEditor: {operation: 'delete', type: 'widget'}"><i class="icon-trash icon-prefer"></i></li>
                     </ul>
                 </div>
             </div>
         </section>
     </li>
 </script>
-
 </body>
 </html>

--- a/lib/css/freeboard/styles.css
+++ b/lib/css/freeboard/styles.css
@@ -8,6 +8,10 @@
  * Correct `block` display not defined in IE 8/9.
  */
 
+:root{
+	color-scheme: light dark;
+}
+
 article,
 aside,
 details,
@@ -413,14 +417,13 @@ freeboard
 ============*/
 
 html {
-	background-color: #101214;
+	/*background-color: #101214;*/
+
 	height: 100%;
 	overflow: hidden;
 }
 
-body {
-	background-color: #101214;
-	color: #8b8b8b;
+body { 
 	font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
 	font-size: 14px;
 	line-height: 20px;
@@ -428,6 +431,8 @@ body {
 	overflow-x: hidden;
 	overflow-y: auto;
 }
+
+
 
 .modal {
 	position: absolute;
@@ -768,7 +773,8 @@ a:focus {
 }
 
 .gridster header {
-	background-color: #272727;
+	/*background-color: #272727;*/
+	background-color: #ddd;
 	height: 30px;
 	margin: 0;
 	padding: 0 10px 0 10px;
@@ -811,7 +817,8 @@ header h1 {
 }
 
 #admin-bar {
-	background-color: #313131;
+	/*background-color: #313131;*/
+	background-color: #fff;		
 	width: 100%;
 	height: 200px;
 	position: relative;
@@ -824,7 +831,7 @@ header h1 {
 	left: 0;
 	right: 0;
 	width: 50px;
-	background-color: #313131;
+	/*background-color: #313131;*/
 	text-align: center;
 	cursor: pointer;
 }
@@ -885,7 +892,7 @@ header h1 {
 
 .table td {
 	border-top: solid 1px #3d3d3d;
-	color: #d3d4d4;
+	/*color: #d3d4d4;*/
 }
 
 #datasources {
@@ -923,7 +930,9 @@ header h1 {
 
 .sub-section {
 	padding: 0;
-	border-bottom: solid 1px #363636;
+	/*border-bottom: solid 1px #363636;*/
+
+	border-bottom: solid 1px #eeeeee;
 	position: relative;
 	overflow: hidden;
 }
@@ -1005,7 +1014,8 @@ ul, ol {
 
 .column-icon {
 	display: inline-block;
-	background-color: white;
+/*	background-color: white;*/
+	background-color: #000;
 	width: 5px;
 	height: 100%;
 }
@@ -1027,7 +1037,7 @@ ul, ol {
 }
 
 .gridster .gs_w {
-	background: #2a2a2a;
+	/*background: #2a2a2a;*/
 	padding: 0px;
 	margin: 0px;
 	overflow: hidden;
@@ -1047,7 +1057,7 @@ ul, ol {
 }
 
 [class^="icon-"],
-[class*=" icon-"] {
+[class*=" icon-"], .icon-prefer {
 	display: inline-block;
 	width: 14px;
 	height: 14px;
@@ -1908,11 +1918,12 @@ ul.datasource-input-suffix {
 	vertical-align: baseline;
 	-webkit-font-smoothing: antialiased;
 	font-style: normal;
-	color: #d3d4d4;
+	/*color: #d3d4d4;*/
 }
 
 .title.bordered {
-	border: solid 3px #d3d4d4;
+	/*border: solid 3px #d3d4d4;*/
+	border: solid 3px #000; 
 	display: inline-block;
 	padding: 2px 17px 2px 17px;
 	line-height: 39px;
@@ -2378,3 +2389,58 @@ input:-moz-placeholder, textarea:-moz-placeholder {
 	height: 100% !important;
 }
 
+/* Use OS dark mode preference */
+@media (prefers-color-scheme: dark){
+	body{
+		background-color: #101214;
+		color: #8b8b8b;
+	}
+
+	.title{
+		color: #d3d4d4;
+	}
+
+	.title.bordered{
+		border: solid 3px #d3d4d4;
+	}
+
+	.table td{
+		color: #d3d4d4;
+	}
+
+	.column-icon{
+		background-color: white;
+	}
+
+	.gridster .gs_w {
+		background: #2a2a2a;	
+	}
+
+	.gridster header {
+		background-color: #272727;	 
+	}
+
+	.sub-section {
+		border-bottom: solid 1px #363636;	
+	}
+
+	.tw-value{
+		color: #d3d4d4;
+	}
+
+	#admin-bar{
+		background-color: #313131;		
+	}
+
+	#toggle-header{
+		background-color: #313131;
+	}
+
+	.icon-prefer{
+		background-image: url("../../../img/glyphicons-halflings-white.png");
+	}
+
+	.mode-toggle{
+		background-image: url('../../../img/lightbulb-on.png');
+	}
+}

--- a/plugins/freeboard/freeboard.widgets.js
+++ b/plugins/freeboard/freeboard.widgets.js
@@ -59,12 +59,13 @@
 		element.empty().append(legendElt);
 
 		freeboard.addStyle('.sparkline-legend', "margin:5px;");
-		freeboard.addStyle('.sparkline-legend-value',
-			'color:white; font:10px arial,san serif; float:left; overflow:hidden; width:50%;');
-		freeboard.addStyle('.sparkline-legend-value span',
-			'font-weight:bold; padding-right:5px;');
-	}
 
+        //BT Default label to black color
+		freeboard.addStyle('.sparkline-legend-value','color:#000; font:10px arial,san serif; float:left; overflow:hidden; width:50%;');
+        freeboard.addStyle('@media (prefers-color-scheme: dark)',".sparkline-legend-value{color:#fff;}"
+        );
+	}
+ 
 	function addValueToSparkline(element, value, legend) {
 		var values = $(element).data().values;
 		var valueMin = $(element).data().valueMin;

--- a/plugins/freeboard/freeboard.widgets.js
+++ b/plugins/freeboard/freeboard.widgets.js
@@ -60,7 +60,7 @@
 
 		freeboard.addStyle('.sparkline-legend', "margin:5px;");
 
-        //BT Default label to black color
+        // Use OS dark mode preference
 		freeboard.addStyle('.sparkline-legend-value','color:#000; font:10px arial,san serif; float:left; overflow:hidden; width:50%;');
         freeboard.addStyle('@media (prefers-color-scheme: dark)',".sparkline-legend-value{color:#fff;}"
         );


### PR DESCRIPTION
I have created a basic 'light-theme' that uses "prefers-color-scheme" media feature, supported by most modern browsers https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-color-scheme

Instant switch between light and dark theme using your OS's preference

<img width="1674" alt="Screen Shot 2021-03-21 at 12 55 58 pm" src="https://user-images.githubusercontent.com/10083575/111913509-d459db80-8a44-11eb-9825-2f36346150ad.png">
